### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   eslint:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/FJancsi/gatsby-blog/security/code-scanning/1](https://github.com/FJancsi/gatsby-blog/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the job or at the workflow root in `.github/workflows/lint.yml`. This ensures that the `GITHUB_TOKEN` is restricted to only the required permissions, typically `contents: read` for code checkout, and potentially `pull-requests: write` if annotations are added to PRs. Since the workflow runs on both PR and push events, and uses ESLint annotations, it's typical to include `contents: read` and `pull-requests: write`, which covers code checkout and PR annotation. The change should be made by inserting a `permissions:` section immediately above the `runs-on: ubuntu-latest` line (line 11), indented correctly for the job-level scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
